### PR TITLE
Remove extra-parameters; use test() instead of typecasting

### DIFF
--- a/jquery.animateNumber.js
+++ b/jquery.animateNumber.js
@@ -89,4 +89,4 @@ $.fn.animateNumber = function(value, options, callback) {
     });
 };
 
-})( jQuery, window, document );
+})( jQuery );


### PR DESCRIPTION
Here are the changes
1. The self-invoking function was only expecting the `jQuery` parameter, but was receiving `window` and `document`.
2. Instead of typecasting the value to a string and using `match()` I thought it would be easier/better to use [`test()`](https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/RegExp/test)
