### PR TITLE
Added an option to format the animated number as currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ $("#numberContainer").animateNumber(Date.now());
 
 **currencyIndicator** (default="$"): The currency symbol to be prepended to the number. Only used if format="currency".
 
-**currencyDecimalSeparator** (default="."): The character to be inserted between the integer and decimal values according to the current locale.
+**currencyDecimalSeparator**: The character to be inserted between groups of thousands when displaying currency. The default value is determined by the browser's current locale.
+
+**currencyDecimalSeparator**: The character to be inserted between the integer and decimal values when displaying currency. The default value is determined by the browser's current locale.
 
 **callback** (optional): Callback to be called at end of animation.
 

--- a/jquery.animateNumber.js
+++ b/jquery.animateNumber.js
@@ -24,7 +24,8 @@
 		floatEndDecimals: 1,
 		format: "default",
 		currencyIndicator: "$",
-		currencyDecimalSeparator: ".",
+		currencyGroupSeparator: (1000).toLocaleString().charAt(1),
+		currencyDecimalSeparator: (1.5).toLocaleString().charAt(1),
 		callback: function() {}
 	};
 
@@ -67,7 +68,6 @@
 			options = {};
 		}
 		options = $.extend({}, defaults, options);
-		var currencyGroupSeparator = (1000).toLocaleString().charAt(1);
 
 		return this.each(function () {
 			var container = $(this);
@@ -77,7 +77,7 @@
 				if (container.data("numeric-value")) {
 					initialValue = container.data("numeric-value");
 				} else {
-					initialValue = container.text().replace(options.currencyIndicator, "").replace(currencyGroupSeparator, "");
+					initialValue = container.text().replace(options.currencyIndicator, "").replace(options.currencyGroupSeparator, "");
 				}
 			} else {
 				initialValue = parseFloat(container.text(), 10);


### PR DESCRIPTION
Thanks for this plugin! I needed to format the animated number as currency so I added a formatCurrency method and some optional parameters to do so.

I put up a test here if you would like to try it out: http://jsbin.com/iCoGOnO/3

This has been tested so far in Chrome, IE10, IE8.
