### PR TITLE
Added support for AMDs, fixed callbacks, added step callback

### DIFF
--- a/jquery.animateNumber.js
+++ b/jquery.animateNumber.js
@@ -5,132 +5,144 @@
  *
  * Used on elements that have a number as content (integer or float)
  * to animate the number to a new value over a short period of time.
- * 
+ *
  * Licensed under the MIT License.
  *
  * Date: 2013-01-08
  * Version: 0.1
  */
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['jquery'], factory);
+    } else if (typeof exports === 'object') {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like environments that support module.exports,
+        // like Node.
+        module.exports = factory();
+    } else {
+        // Browser globals (root is window)
+        root.returnExports = factory();
+    }
+}(this, function($, undefined) {
 
-(function($, undefined) {
+    var defaults = {
+        duration : 5000,
+        easing: "swing",
+        animateOpacity: true,
+        intStepDecimals: 0,
+        intEndDecimals: 0,
+        floatStepDecimals: 4,
+        floatEndDecimals: 1,
+        format: "default",
+        currencyIndicator: "$",
+        currencyGroupSeparator: (1000).toLocaleString().charAt(1),
+        currencyDecimalSeparator: (1.5).toLocaleString().charAt(1),
+        callback: function() {},
+        stepCallback: function() {}
+    };
 
-	var defaults = {
-		duration : 5000,
-		easing: "swing",
-		animateOpacity: true,
-		intStepDecimals: 0,
-		intEndDecimals: 0,
-		floatStepDecimals: 4,
-		floatEndDecimals: 1,
-		format: "default",
-		currencyIndicator: "$",
-		currencyGroupSeparator: (1000).toLocaleString().charAt(1),
-		currencyDecimalSeparator: (1.5).toLocaleString().charAt(1),
-		callback: function() {}
-	};
+    function formatNumber(number, options, decimals) {
+        if (options.format == "currency") {
+            return formatCurrency(number, options);
+        } else {
+            return round(number, decimals);
+        }
+    }
 
-	function formatNumber(number, options, decimals) {
-		if (options.format == "currency") {
-			return formatCurrency(number, options);
-		} else {
-			return round(number, decimals);
-		}
-	}
+    function round(number, decimals) {
+        return Math.round(number*Math.pow(10,decimals))/Math.pow(10,decimals);
+    }
 
-	function round(number, decimals) {
-		return Math.round(number*Math.pow(10,decimals))/Math.pow(10,decimals);
-	}
+    function formatCurrency(number, options) {
+        if (isNaN(number)) { return; }
 
-	function formatCurrency(number, options) {
-		if (isNaN(number)) { return; }
+        var integer     = Math.floor(number);
+        var decimal     = (number - integer).toFixed(options.floatEndDecimals).split('.')[1];
+        var integerPart = integer.toLocaleString();
+        var decimalPart = '';
 
-		var integer     = Math.floor(number);
-		var decimal     = (number - integer).toFixed(options.floatEndDecimals).split('.')[1];
-		var integerPart = integer.toLocaleString();
-		var decimalPart = '';
+        if (parseInt(options.floatEndDecimals) > 0) {
+            decimalPart += options.currencyDecimalSeparator + decimal;
+        }
 
-		if (parseInt(options.floatEndDecimals) > 0) {
-  			decimalPart += options.currencyDecimalSeparator + decimal;
-		}
+        // This check is necessary because IE renders (25).toLocaleString() as 25.00
+        // while Chrome, Firefox and others return it as 25
+        if (integerPart.indexOf(options.currencyDecimalSeparator) >= 0) {
+            integerPart = integerPart.split('.')[0];
+        }
 
-		// This check is necessary because IE renders (25).toLocaleString() as 25.00
-		// while Chrome, Firefox and others return it as 25
-		if (integerPart.indexOf(options.currencyDecimalSeparator) >= 0) {
-  			integerPart = integerPart.split('.')[0];
-		}
+        return options.currencyIndicator + integerPart + decimalPart;
+    }
 
-		return options.currencyIndicator + integerPart + decimalPart;
-	}
+    function isInt(number) {
+        return /^-?[\d]+$/.test(number);
+    }
 
-	function isInt(number) {
-		return /^-?[\d]+$/.test(number);
-	}
+    $.fn.animateNumber = function (value, options) {
+        options = $.extend({}, defaults, options);
 
-	$.fn.animateNumber = function (value, options, callback) {
-		if (typeof options === "function") {
-			callback = options;
-			options = {};
-		}
-		options = $.extend({}, defaults, options);
+        return this.each(function () {
+            var container = $(this);
+            var initialValue;
 
-		return this.each(function () {
-			var container = $(this);
-			var initialValue;
+            if (options.format === "currency") {
+                if (container.data("numeric-value")) {
+                    initialValue = container.data("numeric-value");
+                } else {
+                    initialValue = container.text().replace(options.currencyIndicator, "").replace(options.currencyGroupSeparator, "");
+                }
+            } else {
+                initialValue = parseFloat(container.text(), 10);
+            }
+            if (round(value, options.floatEndDecimals) == round(initialValue, options.floatEndDecimals)) {
+                return;
+            }
+            var type = container.data("type") || (isInt($(this).text()) ? "int" : "float"),
+                stepDecimals, endDecimals,
+                defaultStepDecimals, defaultEndDecimals;
+            if (type == "int") {
+                defaultStepDecimals = options.intStepDecimals;
+                defaultEndDecimals = options.intEndDecimals;
+            } else {
+                defaultStepDecimals = options.floatStepDecimals;
+                defaultEndDecimals = options.floatEndDecimals;
+            }
+            stepDecimals = container.data("stepDecimals") || defaultStepDecimals;
+            endDecimals = container.data("endDecimals") || defaultEndDecimals;
 
-			if (options.format === "currency") {
-				if (container.data("numeric-value")) {
-					initialValue = container.data("numeric-value");
-				} else {
-					initialValue = container.text().replace(options.currencyIndicator, "").replace(options.currencyGroupSeparator, "");
-				}
-			} else {
-				initialValue = parseFloat(container.text(), 10);
-			}
-			if (round(value, options.floatEndDecimals) == round(initialValue, options.floatEndDecimals)) {
-				return;
-			}
-			var type = container.data("type") || (isInt($(this).text()) ? "int" : "float"),
-				stepDecimals, endDecimals,
-				defaultStepDecimals, defaultEndDecimals;
-			if (type == "int") {
-				defaultStepDecimals = options.intStepDecimals;
-				defaultEndDecimals = options.intEndDecimals;
-			} else {
-				defaultStepDecimals = options.floatStepDecimals;
-				defaultEndDecimals = options.floatEndDecimals;
-			}
-			stepDecimals = container.data("stepDecimals") || defaultStepDecimals;
-			endDecimals = container.data("endDecimals") || defaultEndDecimals;
+            // animate opacity
+            if (options.animateOpacity) {
+                container.animate({opacity: 0.2}, {
+                    duration: options.duration/2,
+                    easing: options.easing,
+                    complete: function() {
+                        container.animate({opacity: 1}, {
+                            duration: options.duration/2,
+                            easing: options.easing
+                        });
+                    }
+                });
+            }
+            // animate number
+            $({number: initialValue}).animate({number: value}, {
+                duration: options.duration,
+                easing: options.easing,
+                step: function() {
+                    container.text(formatNumber(this.number, options, stepDecimals));
+                    if (typeof options.stepCallback === "function") {
+                        options.stepCallback.call(this, container, this.number);
+                    }
+                },
+                complete: function() {
+                    container.data("numeric-value", this.number);
+                    container.text(formatNumber(this.number, options, endDecimals));
+                    if (typeof options.callback === "function") {
+                        options.callback.call(this, container, this.number);
+                    }
+                }
+            });
+        });
+    };
 
-			// animate opacity
-			if (options.animateOpacity) {
-				container.animate({opacity: 0.2}, {
-					duration: options.duration/2,
-					easing: options.easing,
-					complete: function() {
-						container.animate({opacity: 1}, {
-							duration: options.duration/2,
-							easing: options.easing
-						});
-					}
-				});
-			}
-			// animate number
-			$({number: initialValue}).animate({number: value}, {
-				duration: options.duration,
-				easing: options.easing,
-				step: function() {
-					container.text(formatNumber(this.number, options, stepDecimals));
-				},
-				complete: function() {
-					container.data("numeric-value", this.number);
-					container.text(formatNumber(this.number, options, endDecimals));
-					if (typeof options.callback === "function") {
-						options.callback.call(container);
-					}
-				}
-			});
-		});
-	};
-
-})(jQuery);
+}));

--- a/jquery.animateNumber.js
+++ b/jquery.animateNumber.js
@@ -27,123 +27,127 @@
     }
 }(this, function($, undefined) {
 
-    var defaults = {
-        duration : 5000,
-        easing: "swing",
-        animateOpacity: true,
-        intStepDecimals: 0,
-        intEndDecimals: 0,
-        floatStepDecimals: 4,
-        floatEndDecimals: 1,
-        format: "default",
-        currencyIndicator: "$",
-        currencyGroupSeparator: (1000).toLocaleString().charAt(1),
-        currencyDecimalSeparator: (1.5).toLocaleString().charAt(1),
-        callback: function() {},
-        stepCallback: function() {}
-    };
+	var defaults = {
+		duration : 5000,
+		easing: "swing",
+		animateOpacity: true,
+		intStepDecimals: 0,
+		intEndDecimals: 0,
+		floatStepDecimals: 4,
+		floatEndDecimals: 1,
+		format: "default",
+		currencyIndicator: "$",
+		currencyGroupSeparator: (1000).toLocaleString().charAt(1),
+		currencyDecimalSeparator: (1.5).toLocaleString().charAt(1),
+		callback: function() {},
+		stepCallback: function() {}
+	};
 
-    function formatNumber(number, options, decimals) {
-        if (options.format == "currency") {
-            return formatCurrency(number, options);
-        } else {
-            return round(number, decimals);
-        }
-    }
+	function formatNumber(number, options, decimals) {
+		if (options.format == "currency") {
+			return formatCurrency(number, options);
+		} else {
+			return round(number, decimals);
+		}
+	}
 
-    function round(number, decimals) {
-        return Math.round(number*Math.pow(10,decimals))/Math.pow(10,decimals);
-    }
+	function round(number, decimals) {
+		return Math.round(number*Math.pow(10,decimals))/Math.pow(10,decimals);
+	}
 
-    function formatCurrency(number, options) {
-        if (isNaN(number)) { return; }
+	function formatCurrency(number, options) {
+		if (isNaN(number)) { return; }
 
-        var integer     = Math.floor(number);
-        var decimal     = (number - integer).toFixed(options.floatEndDecimals).split('.')[1];
-        var integerPart = integer.toLocaleString();
-        var decimalPart = '';
+		var integer     = Math.floor(number);
+		var decimal     = (number - integer).toFixed(options.floatEndDecimals).split('.')[1];
+		var integerPart = integer.toLocaleString();
+		var decimalPart = '';
 
-        if (parseInt(options.floatEndDecimals) > 0) {
-            decimalPart += options.currencyDecimalSeparator + decimal;
-        }
+		if (parseInt(options.floatEndDecimals) > 0) {
+  			decimalPart += options.currencyDecimalSeparator + decimal;
+		}
 
-        // This check is necessary because IE renders (25).toLocaleString() as 25.00
-        // while Chrome, Firefox and others return it as 25
-        if (integerPart.indexOf(options.currencyDecimalSeparator) >= 0) {
-            integerPart = integerPart.split('.')[0];
-        }
+		// This check is necessary because IE renders (25).toLocaleString() as 25.00
+		// while Chrome, Firefox and others return it as 25
+		if (integerPart.indexOf(options.currencyDecimalSeparator) >= 0) {
+  			integerPart = integerPart.split('.')[0];
+		}
 
-        return options.currencyIndicator + integerPart + decimalPart;
-    }
+		return options.currencyIndicator + integerPart + decimalPart;
+	}
 
-    function isInt(number) {
-        return /^-?[\d]+$/.test(number);
-    }
+	function isInt(number) {
+		return /^-?[\d]+$/.test(number);
+	}
 
-    $.fn.animateNumber = function (value, options) {
-        options = $.extend({}, defaults, options);
+	$.fn.animateNumber = function (value, options, callback) {
+		if (typeof options === "function") {
+			callback = options;
+			options = {};
+		}
+		options = $.extend({}, defaults, options);
 
-        return this.each(function () {
-            var container = $(this);
-            var initialValue;
+		return this.each(function () {
+			var container = $(this);
+			var initialValue;
 
-            if (options.format === "currency") {
-                if (container.data("numeric-value")) {
-                    initialValue = container.data("numeric-value");
-                } else {
-                    initialValue = container.text().replace(options.currencyIndicator, "").replace(options.currencyGroupSeparator, "");
-                }
-            } else {
-                initialValue = parseFloat(container.text(), 10);
-            }
-            if (round(value, options.floatEndDecimals) == round(initialValue, options.floatEndDecimals)) {
-                return;
-            }
-            var type = container.data("type") || (isInt($(this).text()) ? "int" : "float"),
-                stepDecimals, endDecimals,
-                defaultStepDecimals, defaultEndDecimals;
-            if (type == "int") {
-                defaultStepDecimals = options.intStepDecimals;
-                defaultEndDecimals = options.intEndDecimals;
-            } else {
-                defaultStepDecimals = options.floatStepDecimals;
-                defaultEndDecimals = options.floatEndDecimals;
-            }
-            stepDecimals = container.data("stepDecimals") || defaultStepDecimals;
-            endDecimals = container.data("endDecimals") || defaultEndDecimals;
+			if (options.format === "currency") {
+				if (container.data("numeric-value")) {
+					initialValue = container.data("numeric-value");
+				} else {
+					initialValue = container.text().replace(options.currencyIndicator, "").replace(options.currencyGroupSeparator, "");
+				}
+			} else {
+				initialValue = parseFloat(container.text(), 10);
+			}
+			if (round(value, options.floatEndDecimals) == round(initialValue, options.floatEndDecimals)) {
+				return;
+			}
+			var type = container.data("type") || (isInt($(this).text()) ? "int" : "float"),
+				stepDecimals, endDecimals,
+				defaultStepDecimals, defaultEndDecimals;
+			if (type == "int") {
+				defaultStepDecimals = options.intStepDecimals;
+				defaultEndDecimals = options.intEndDecimals;
+			} else {
+				defaultStepDecimals = options.floatStepDecimals;
+				defaultEndDecimals = options.floatEndDecimals;
+			}
+			stepDecimals = container.data("stepDecimals") || defaultStepDecimals;
+			endDecimals = container.data("endDecimals") || defaultEndDecimals;
 
-            // animate opacity
-            if (options.animateOpacity) {
-                container.animate({opacity: 0.2}, {
-                    duration: options.duration/2,
-                    easing: options.easing,
-                    complete: function() {
-                        container.animate({opacity: 1}, {
-                            duration: options.duration/2,
-                            easing: options.easing
-                        });
-                    }
-                });
-            }
-            // animate number
-            $({number: initialValue}).animate({number: value}, {
-                duration: options.duration,
-                easing: options.easing,
-                step: function() {
-                    container.text(formatNumber(this.number, options, stepDecimals));
-                    if(typeof options.stepCallback === 'function') {
-                        options.stepCallback().call(this, container, this.number);
-                    }
-                },
-                complete: function() {
-                    container.data("numeric-value", this.number);
-                    container.text(formatNumber(this.number, options, endDecimals));
-                    if (typeof options.callback === "function") {
-                        options.callback.call(this, container, this.number);
-                    }
-                }
-            });
-        });
-    };
+			// animate opacity
+			if (options.animateOpacity) {
+				container.animate({opacity: 0.2}, {
+					duration: options.duration/2,
+					easing: options.easing,
+					complete: function() {
+						container.animate({opacity: 1}, {
+							duration: options.duration/2,
+							easing: options.easing
+						});
+					}
+				});
+			}
+			// animate number
+			$({number: initialValue}).animate({number: value}, {
+				duration: options.duration,
+				easing: options.easing,
+				step: function() {
+					container.text(formatNumber(this.number, options, stepDecimals));
+					if(typeof options.stepCallback === 'function') {
+						options.stepCallback(this, container, this.number);
+					}
+				},
+				complete: function() {
+					container.data("numeric-value", this.number);
+					container.text(formatNumber(this.number, options, endDecimals));
+					if (typeof options.callback === "function") {
+						options.callback.call(this, container, this.number);
+					}
+				}
+			});
+		});
+	};
 
 }));

--- a/jquery.animateNumber.js
+++ b/jquery.animateNumber.js
@@ -5,12 +5,13 @@
  *
  * Used on elements that have a number as content (integer or float)
  * to animate the number to a new value over a short period of time.
- *
+ * 
  * Licensed under the MIT License.
  *
  * Date: 2013-01-08
  * Version: 0.1
  */
+
 (function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
@@ -130,8 +131,8 @@
                 easing: options.easing,
                 step: function() {
                     container.text(formatNumber(this.number, options, stepDecimals));
-                    if (typeof options.stepCallback === "function") {
-                        options.stepCallback.call(this, container, this.number);
+                    if(typeof options.stepCallback === 'function') {
+                        options.stepCallback().call(this, container, this.number);
                     }
                 },
                 complete: function() {


### PR DESCRIPTION
Hi,

(Sorry for duplicate PR, I use PHPStorm at work and it messed up the indentation etc.)

This is a much better plugin compared to the other jquery-animateNumber on GitHub as it supports decimals and currency properly!
Only thing it doesn't do, compared, is the "cool" callback functions which would allow you to style the number based on it's current step. So that's added. Also you were referring to options.callback when in fact it's passed in as a parameter so that's fixed (callbacks now go in options).

```
var options: {
    // Normal options here
    callback: function() { },
    stepCallback: function() { }
};
```
